### PR TITLE
Add fail on detection flag

### DIFF
--- a/blocklint/main.py
+++ b/blocklint/main.py
@@ -35,8 +35,11 @@ def main():
                 total_issues += process_file(handle, file, word_checkers,
                                              args['end_pos'])
 
-    if args.max_issue_threashold and args.max_issue_threashold <= total_issues:
-        exit(1)
+    if (args['max_issue_threashold'] is not None
+            and args['max_issue_threashold'] <= total_issues):
+        print(f"Found {total_issues} issues, but only "
+              f"{args['max_issue_threashold']} permitted!")
+        sys.exit(1)
 
 
 def process_file(input_file, file_name, word_checkers, end_pos):

--- a/blocklint/main.py
+++ b/blocklint/main.py
@@ -24,22 +24,32 @@ ignore_class = '[^a-zA-Z0-9]'
 def main():
     args = get_args()
     word_checkers = generate_re(args)
+    total_issues = 0
 
     if args['stdin']:
-        process_file(sys.stdin, 'stdin', word_checkers, args['end_pos'])
+        total_issues += process_file(sys.stdin, 'stdin', word_checkers,
+                                     args['end_pos'])
     else:
         for file in args['files']:
             with open(file, 'r') as handle:
-                process_file(handle, file, word_checkers, args['end_pos'])
+                total_issues += process_file(handle, file, word_checkers,
+                                             args['end_pos'])
+
+    if args.max_issue_threashold and args.max_issue_threashold <= total_issues:
+        exit(1)
+
 
 def process_file(input_file, file_name, word_checkers, end_pos):
+    num_matched = 0
     try:
         for i, line in enumerate(input_file, 1):
             for match in check_line(line, word_checkers,
                                     file_name, i, end_pos):
+                num_matched += 1
                 print(match)
     except FileNotFoundError:
         pass
+    return num_matched
 
 
 def get_args(args=None):
@@ -60,6 +70,9 @@ def get_args(args=None):
                         help='Show the end position of a match in output')
     parser.add_argument('--stdin', action='store_true',
                         help='Use stdin as input instead of file list')
+    parser.add_argument("--max-issue-threashold", type=int, required=False,
+                        help='Cause non-zero exit status of more than this '
+                        'many issues found')
     args = vars(parser.parse_args(args))
 
     # from least to most restrictive
@@ -142,6 +155,7 @@ def check_line(line, word_checkers, file, line_number, end_pos=False):
                 start=match.start()+1,
                 end=match.end(),
                 word=word)
+
 
 if __name__ == '__main__':
     main()

--- a/tests/test_max_issue_threashold.sh
+++ b/tests/test_max_issue_threashold.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e 
+
+echo "No threashold..."
+blocklint sample_files/test.* > /dev/null
+
+echo "Issue count under threashold..."
+blocklint sample_files/test.* --max-issue-threashold=100 > /dev/null
+
+echo "Issue count one over threashold"
+blocklint sample_files/test.* --max-issue-threashold=28 > /dev/null
+
+echo "Issue count at threashold"
+if blocklint sample_files/test.* --max-issue-threashold=27 > /dev/null; then
+    exit 1
+fi
+
+echo "Issue count under threashold"
+if blocklint sample_files/test.* --max-issue-threashold=20 > /dev/null; then
+    exit 1
+fi
+
+echo "Done"


### PR DESCRIPTION
I am using blocklint as part of a CI/CD pipeline on a protected branch.

I would like blocklint to exit with a non-zero status if it encounters more than a specific number of instances of non-inclusive language, so that my pipeline can prevent merging to a protected branch when new instances of non-inclusive language are being added to a codebase.

This PR adds a new argument to blocklint that implements this behavior. Included is a test file to cover the proposed changes. 

I also added a second line of whitespace between function definitions, conforming to [PEP8](https://www.python.org/dev/peps/pep-0008/#blank-lines) as suggested by `flake8`. Happy to remove that change if it is not welcome in this project. 