### PR TITLE
Add pragma directive

### DIFF
--- a/blocklint/main.py
+++ b/blocklint/main.py
@@ -32,6 +32,7 @@ def main():
             with open(file, 'r') as handle:
                 process_file(handle, file, word_checkers, args['end_pos'])
 
+
 def process_file(input_file, file_name, word_checkers, end_pos):
     try:
         for i, line in enumerate(input_file, 1):
@@ -134,6 +135,11 @@ def check_line(line, word_checkers, file, line_number, end_pos=False):
     fmt_str = '{file}:{line_number}:{start}: use of "{word}"'
     if end_pos:
         fmt_str = '{file}:{line_number}:{start}:{end}: use of "{word}"'
+
+    pragma_regex = re.compile(r"blocklint:.*pragma")
+    if pragma_regex.search(line):
+        return
+
     for word, regex in word_checkers.items():
         for match in regex.finditer(line):
             yield fmt_str.format(
@@ -142,6 +148,7 @@ def check_line(line, word_checkers, file, line_number, end_pos=False):
                 start=match.start()+1,
                 end=match.end(),
                 word=word)
+
 
 if __name__ == '__main__':
     main()

--- a/tests/acceptance_test.sh
+++ b/tests/acceptance_test.sh
@@ -40,4 +40,9 @@ echo "  stdin"
 diff <(cat tests/sample_files/test.{cc,py,txt} |
         blocklint --stdin ) \
     tests/sample_files/stdin.txt
+
+echo "  pragma"
+diff <(cat tests/sample_files/test_pragma.{cc,py,txt} |
+        blocklint --stdin ) \
+    tests/sample_files/pragma.txt
 echo Passed!

--- a/tests/sample_files/pragma.txt
+++ b/tests/sample_files/pragma.txt
@@ -1,0 +1,3 @@
+test_pragma.cc:6:20: use of "slave"
+test_pragma.py:6:20: use of "slave"
+test_pragma.txt:11:18: use of "whitelist"

--- a/tests/sample_files/test_pragma.cc
+++ b/tests/sample_files/test_pragma.cc
@@ -1,0 +1,7 @@
+int test(std::vector<int> blacklist, int master){ // blocklint: pragma
+    // looking for master/slave blocklint: pragma
+    int slave = 0; // blocklint: some other tags pragma
+    for(int i : blacklist) // blocklint: pragma
+        if(i == master) // blocklint: pragma
+            return slave;
+}

--- a/tests/sample_files/test_pragma.py
+++ b/tests/sample_files/test_pragma.py
@@ -1,0 +1,10 @@
+def main(blacklist, white_list):  # blocklint: pragma
+    # looking for master slave blocklint: pragma
+    for item in blacklist:  # blocklint: some other tags pragma
+        if item in white_list:  # blocklint: pragma
+            slave = item  # blocklint: pragma
+            assert slave == item
+
+
+if __name__ == '__main__':
+    main("", "")

--- a/tests/sample_files/test_pragma.txt
+++ b/tests/sample_files/test_pragma.txt
@@ -1,0 +1,11 @@
+push to master # blocklint: pragma
+TODO add user to black_list # blocklint: pragma
+BlAcKlIsT # blocklint: pragma
+B_Lack_List # blocklint: pragma
+B-Lack-List # blocklint: pragma
+B:Lack:List # blocklint: pragma
+blacklisted # blocklint: some other tags pragma
+this is aBlacklist # blocklint: pragma
+b.la-ck_list # blocklint: pragma
+find master/slave # blocklint: pragma
+Add file type to whi_te-list


### PR DESCRIPTION
It is sometimes be necessary to include a non-inclusive term, for instance, because an external library uses it as a parameter name, or because it is in the name of a branch in another repo that I do not control the name of.

I would like to be able to flag such lines with an indication for blocklint that I know about them and don't want to be warned.
This is particularly relevent when using blocklint as part of a CI/CD pipeline where output from blocklint is treated as an error.

This PR adds a directive: "blocklint: pragma", that instructs blocklint to ignore any lint on a line containing that suffix.
Included are tests demonstrating how this can be used.