### PR TITLE
Add default module entrypoint

### DIFF
--- a/blocklint/__main__.py
+++ b/blocklint/__main__.py
@@ -1,0 +1,2 @@
+from blocklint.main import main
+main()

--- a/tests/acceptance_test.sh
+++ b/tests/acceptance_test.sh
@@ -44,4 +44,9 @@ diff <(cat tests/sample_files/test.{cc,py,txt} |
 echo "  pragma"
 diff <(blocklint tests/sample_files/test_pragma.{cc,py,txt}) \
     tests/sample_files/pragma.txt
+
+echo "  module entrypoint"
+diff <(python -m blocklint tests/sample_files/test.{cc,py,txt}) \
+    tests/sample_files/default.txt
+
 echo Passed!


### PR DESCRIPTION
-> Allows invocation with python -m blocklint after installation, following standard conventions for linting tools.

-> If possible, package should be redeployed to PyPI after merging this PR