### PR TITLE
Add option to skip specific files

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ to the start position.
 
 The `--stdin` flag will take values from stdin instead of a file or directory.
 
+The `--skip-files` flag takes a comma-or-newline separated list of paths to files
+that should not be checked by blocklint. This is useful when running blocklint on
+a large directory.
+
 ## Configuration
 
 Blocklint supports the standard `ini` configuration format used by many other

--- a/blocklint/main.py
+++ b/blocklint/main.py
@@ -5,7 +5,8 @@ import argparse
 import configparser
 import os
 from collections import OrderedDict
-from typing import Dict, Set, Union
+if sys.version_info >= (3, 5):
+    from typing import Dict, Set, Union
 
 
 ignore_class = '[^a-zA-Z0-9]'

--- a/blocklint/main.py
+++ b/blocklint/main.py
@@ -86,7 +86,7 @@ def get_args(args=None):
                         'many issues found')
     parser.add_argument("--skip-files", type=str,
                         help='Paths to files that should _not_ be checked by'
-                        'by blocklint, even if within the a checked directory')
+                        'blocklint, even if within the a checked directory')
     args = vars(parser.parse_args(args))
 
     config_paths = [

--- a/blocklint/main.py
+++ b/blocklint/main.py
@@ -5,6 +5,7 @@ import argparse
 import configparser
 import os
 from collections import OrderedDict
+from typing import Dict, Set, Union
 
 
 ignore_class = '[^a-zA-Z0-9]'
@@ -56,6 +57,8 @@ def process_file(input_file, file_name, word_checkers, end_pos):
                 print(match)
     except FileNotFoundError:
         pass
+    except UnicodeDecodeError:
+        pass
     return num_matched
 
 
@@ -80,6 +83,9 @@ def get_args(args=None):
     parser.add_argument("--max-issue-threshold", type=int, required=False,
                         help='Cause non-zero exit status of more than this '
                         'many issues found')
+    parser.add_argument("--skip-files", type=str,
+                        help='Paths to files that should _not_ be checked by'
+                        'by blocklint, even if within the a checked directory')
     args = vars(parser.parse_args(args))
 
     config_paths = [
@@ -94,7 +100,7 @@ def get_args(args=None):
     config = configparser.ConfigParser()
     for path in present_config_files:
         config.read(path)
-    config_settings = {}
+    config_settings = {}  # type: Dict[str, Union[str, bool, int, Set[str]]]
     if 'blocklint' in config:
         config_settings = dict(config['blocklint'])
     for key in args:
@@ -103,7 +109,15 @@ def get_args(args=None):
                 config_settings[key] = config.getboolean('blocklint', key)
             if key in ['max_issue_threshold']:
                 config_settings[key] = config.getint('blocklint', key)
+            if key in ['skip_files']:
+                config_settings[key] = config.get('blocklint', key)
             args[key] = config_settings[key]
+    if args['skip_files'] is not None:
+        # config files have multiline args
+        skip_files = args['skip_files'].split('\n')
+        skip_files = [path for line in skip_files
+                      for path in line.split(',')]
+        args['skip_files'] = set(skip_files)
 
     # from least to most restrictive
     wordlists = ('blocklist', 'wordlist', 'exactlist')
@@ -141,6 +155,8 @@ def get_args(args=None):
         # isabs detects pipes
         elif os.path.isfile(file) or os.path.isabs(file):
             files.append(file)
+    if args['skip_files'] is not None:
+        files = [file for file in files if file not in args['skip_files']]
 
     args['files'] = files
 

--- a/tests/config_tests/skip_files/tox.ini
+++ b/tests/config_tests/skip_files/tox.ini
@@ -1,0 +1,11 @@
+[blocklint]
+max_issue_threshold=21
+skip_files=first_file,
+    second_file,
+    another_file,
+    multi_line,with_two_files,../../sample_files/test.py,
+    final_line
+
+[someotherproject]
+not_our_arg=0
+max_issue_threshold=500

--- a/tests/test_configfiles.sh
+++ b/tests/test_configfiles.sh
@@ -18,7 +18,7 @@ if blocklint tests/sample_files/test.* > /dev/null; then
 fi
 
 echo "  Local .blocklint config with command line overrides"
-blocklint tests/sample_files/test.* --max-issue-threshold=30 > /dev/null || echo "Failed"
+blocklint tests/sample_files/test.* --max-issue-threshold=30 > /dev/null || (echo "Failed" && exit 1)
 rm ./.blocklint
 
 echo " Local setup.cfg config"
@@ -29,7 +29,7 @@ if blocklint ../../sample_files/test.* > /dev/null; then
 fi
 
 echo "  Local .setup.cfg config with command line overrides"
-blocklint tests/sample_files/test.* --max-issue-threshold=30 > /dev/null || echo "Failed"
+blocklint tests/sample_files/test.* --max-issue-threshold=30 > /dev/null || (echo "Failed" && exit 1)
 
 
 echo " Local tox.ini config"
@@ -40,7 +40,7 @@ if blocklint ../../sample_files/test.* > /dev/null; then
 fi
 
 echo "  Local .tox.ini config with command line overrides"
-blocklint tests/sample_files/test.* --max-issue-threshold=30 > /dev/null || echo "Failed"
+blocklint tests/sample_files/test.* --max-issue-threshold=30 > /dev/null || (echo "Failed" && exit 1)
 
 echo " Multiple local configs (tox)"
 cd ../tox_setup
@@ -61,5 +61,9 @@ cd ../flag_and_list
 diff <(cat ../../sample_files/test.{cc,py,txt} |
         blocklint --stdin ) \
     ../../sample_files/stdin_wordlist.txt
+
+echo " Skip-files in config"
+cd ../skip_files
+blocklint ../../sample_files/test.* > /dev/null || (echo "Failed" && exit 1)
 
 echo Passed!

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -67,6 +67,7 @@ def test_get_args_wordlists(mocker):
         'end_pos': False,
         'stdin': False,
         'max_issue_threshold': None,
+        'skip_files': None,
         'wordlist': []}
 
     # set each list in turn
@@ -77,6 +78,7 @@ def test_get_args_wordlists(mocker):
         'files': [],
         'end_pos': False,
         'stdin': True,
+        'skip_files': None,
         'max_issue_threshold': None,
         'wordlist': []}
 
@@ -87,6 +89,7 @@ def test_get_args_wordlists(mocker):
         'files': [],
         'end_pos': False,
         'stdin': False,
+        'skip_files': None,
         'max_issue_threshold': None,
         'wordlist': []}
 
@@ -97,6 +100,7 @@ def test_get_args_wordlists(mocker):
         'files': [],
         'end_pos': False,
         'stdin': False,
+        'skip_files': None,
         'max_issue_threshold': None,
         'wordlist': ['test2']}
 
@@ -110,6 +114,7 @@ def test_get_args_wordlists(mocker):
         'files': [],
         'end_pos': True,
         'stdin': False,
+        'skip_files': None,
         'max_issue_threshold': None,
         'wordlist': ['test3']}
 
@@ -124,6 +129,7 @@ def test_get_args_wordlists(mocker):
         'files': [],
         'end_pos': True,
         'stdin': False,
+        'skip_files': None,
         'max_issue_threshold': None,
         'wordlist': []}
 
@@ -136,8 +142,26 @@ def test_get_args_wordlists(mocker):
         'files': [],
         'end_pos': False,
         'stdin': False,
+        'skip_files': None,
         'max_issue_threshold': None,
         'wordlist': ['test']}
+
+    args = bl.get_args(('--blocklist test1 '
+                        '--skip-files tests/sample_files/test.py,'
+                        'tests/sample_files/test.txt '
+                        'files tests/sample_files/test.py '
+                        'tests/sample_files/test.cc').split())
+
+    # Test skip_files filter
+    assert args == {
+        'blocklist': ['test1'],
+        'exactlist': [],
+        'files': ['tests/sample_files/test.cc'],
+        'end_pos': False,
+        'stdin': False,
+        'skip_files': set(('tests/sample_files/test.py', 'tests/sample_files/test.txt')),
+        'max_issue_threshold': None,
+        'wordlist': []}
 
 
 def test_ignore_special():


### PR DESCRIPTION
-> Blocklint currently operates over all files in a specified directory, or over an explicit list of files.

-> In some projects, binary files or other files that are not utf-8 encoded may be present in the directory blocklint should operate over.

-> Users would like some way to indicate that certain files should not be checked

-> Users would also like blocklint to fail gracefully if a non utf-8 encoded file is read.

-> This commit introduces a skip-file argument that is a comma separated list of paths that should not be processed by blocklint. Alternatively a config file may specify such a list of paths spread over multiple lines.

-> Additionally, a new exception is caught in process_file. This was added because a user complained that blocklint errors out with an uninterpretable message when accidentally run on a binary file. I think the desired behavior for this case is to silently skip the file.