### PR TITLE
Ensure skip_files are absolute paths

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ in scope.
 
 ## Requirements and Installation
 Blocklint is written in python and uses minimal, standard libraries.  It has
-been tested for python >= 2.7  To install:
+been tested for python >= 3.7  To install:
 
 ```
 pip install blocklint

--- a/blocklint/main.py
+++ b/blocklint/main.py
@@ -116,7 +116,7 @@ def get_args(args=None):
     if args['skip_files'] is not None:
         # config files have multiline args
         skip_files = args['skip_files'].split('\n')
-        skip_files = [path for line in skip_files
+        skip_files = [os.path.abspath(path) for line in skip_files
                       for path in line.split(',')]
         args['skip_files'] = set(skip_files)
 

--- a/blocklint/main.py
+++ b/blocklint/main.py
@@ -157,7 +157,8 @@ def get_args(args=None):
         elif os.path.isfile(file) or os.path.isabs(file):
             files.append(file)
     if args['skip_files'] is not None:
-        files = [file for file in files if file not in args['skip_files']]
+        files = [file for file in files
+            if os.path.abspath(file) not in args['skip_files']]
 
     args['files'] = files
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ python =
 deps =
   pytest
   pytest-mock
-whitelist_externals =
+allowlist_externals =
   bash
 commands =
   python -m pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
-envlist = py27, py35, py36, py37, py38
+envlist = py37, py38, py39
 isolated_build = True
 
 [gh-actions]
 python =
-    2.7: py27
-    3.6: py36
     3.7: py37
     3.8: py38
+    3.9: py39
 
 [testenv]
 deps =


### PR DESCRIPTION
The filtering done on line 160 requires an exact path match. This change
ensures skip files are absolute paths when parsed.