### PR TITLE
Ignore entire docstrings witha single `# blocklint ... pragma` comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 *.pyc
 *.egg-info/
 .tox/
+blocklint/version.py

--- a/blocklint/main.py
+++ b/blocklint/main.py
@@ -45,17 +45,17 @@ def main(args=None):
                    issues=total_issues,
                    max=args['max_issue_threshold']))
         sys.exit(1)
-        
+
 
 def clean_ignored_docstrings(lines):
-    end_pattern = re.compile(r'("""\s*#\s*blocklint:.*pragma$|\'\'\'\s*#\s*blocklint:.*pragma$)')
+    end_pattern = re.compile(r'(("""|\'\'\')\s*#\s*blocklint:.*pragma\s*$)')
     lines_to_clear = []
 
     for i, line in enumerate(lines):
         match = end_pattern.search(line)
         if match:
             start_quote = match.group(1)[:3]  # This is either """ or '''
-            
+
             if start_quote in line[:-(len(match.group(1)))]:
                 # single line docstring
                 lines_to_clear.append((i, i+1))
@@ -65,7 +65,7 @@ def clean_ignored_docstrings(lines):
                     if start_quote in lines[j]:
                         lines_to_clear.append((j, i+1))
                         break
-                        
+
     for start_line, stop_line in lines_to_clear:
         for ignored_line in range(start_line, stop_line):
             lines[ignored_line] = ""

--- a/blocklint/main.py
+++ b/blocklint/main.py
@@ -73,47 +73,6 @@ def clean_ignored_docstrings(lines):
     return lines
 
 
-def clean_ignored_docstrings_old(lines):
-    docstring_delimiters = ('"""', 'r"""', "'''", "r'''")
-    i = 0
-    while i < len(lines):
-        line = lines[i].strip()
-
-        if line.startswith(docstring_delimiters):
-            if "'''" in line[3:] or '"""' in line[3:]:
-                # case: single line docstring
-                if "# blocklint" in line and "pragma" in line:
-                    # ignore the entire docstring
-                    lines[i] = ""
-                    i += 1
-                    continue
-                else:
-                    # don't ignore the docstring
-                    i += 1
-                    continue
-            else:
-                # case: multi-line docstring
-                line_number_of_start = i
-                i += 1
-                while "'''" not in lines[i] and '"""' not in lines[i] and i < len(lines):
-                    i += 1
-                # found the closing delimiter
-                if "# blocklint" in lines[i] and "pragma" in lines[i]:
-                    # ignore the entire docstring
-                    for j in range(line_number_of_start, i+1):
-                        lines[j] = ""
-                    i += 1
-                    continue
-                else:
-                    # don't ignore the docstring
-                    i += 1
-                    continue
-        else:
-            i += 1
-
-    return lines
-
-
 def process_file(input_file, file_name, word_checkers, end_pos):
     num_matched = 0
     try:

--- a/tests/docstring_tests/docstring_test_file.py
+++ b/tests/docstring_tests/docstring_test_file.py
@@ -1,0 +1,73 @@
+# multi-line doublequote docstring containing blocked words, not ignored
+def process_data(data):
+    """
+    Process the given data and return a modified version to add to whitelist.
+    
+    Parameters:
+    - data: The master data to be processed, can be a list or dict.
+    
+    Returns:
+    - A modified version of the input data, where each element or value is doubled.
+    """
+    if isinstance(data, list):
+        return [item * 2 for item in data]
+    elif isinstance(data, dict):
+        return {k: v * 2 for k, v in data.items()}
+    return data
+
+# multi-line singlequoate docstring containing blocked words, full docstring ignored
+def compile_allowlist_rules(rules):
+    '''
+    Compile whitelist rules into a usable format.
+    
+    Parameters:
+    - rules: A list or dictionary of rules to compile.
+    
+    Returns:
+    - A dictionary with each rule mapped to its compiled form. This is a placeholder for actual compilation logic.
+    '''  # blocklint:  pragma
+    compiled_rules = {rule: "compiled" for rule in rules}
+    return compiled_rules
+
+# single-line singlequote docstring containing blocked words, not ignored
+def relay_to_slave_nodes(message):
+    '''Relay a message to all slave nodes in the network.'''
+    slave_nodes = ["Node 1", "Node 2", "Node 3"]
+    for node in slave_nodes:
+        print(f"Message '{message}' relayed to {node}")
+
+# single-line doublequote docstring containing blocked words, ignored
+def filter_blocklist_items(items, blocklist):
+    """Filter out items that are in the blacklist."""  # blocklint:  pragma
+    filtered_items = [item for item in items if item not in blocklist]
+    return filtered_items
+
+
+# multi-line doublequote raw docstring containing blocked words, full docstring ignored
+def create_generic_function():
+    r"""
+    A generic function that performs a simple operation.
+    
+    Side Effects:
+    - Prints a master message indicating a simple operation has been performed.
+    """  # blocklint:  pragma
+    print("Performing a simple operation...")
+
+# multi-line singlequote raw docstring containing blocked words, not ignored
+def synchronize_slave_database(database):
+    r"""
+    Synchronize the slave database with the master database.
+    
+    Parameters:
+    - database: The slave database to be synchronized. This is a placeholder for the actual database object.
+    
+    Side Effects:
+    - Assumes synchronization logic is implemented, updates the slave database to match the master database.
+    """
+    slave_database = database
+    print("Slave database synchronized.")
+
+# single-line doublequote raw docstring containing blocked words, ignored
+def create_generic_function():
+    r"""A generic function that performs a simple whitelist operation."""  # blocklint:  pragma
+    print("Performing a simple whitelist operation...")  # blocklint:  pragma

--- a/tests/docstring_tests/sample_files/docstring_test_file_1.py
+++ b/tests/docstring_tests/sample_files/docstring_test_file_1.py
@@ -2,10 +2,10 @@
 def process_data(data):
     """
     Process the given data and return a modified version to add to whitelist.
-    
+
     Parameters:
     - data: The master data to be processed, can be a list or dict.
-    
+
     Returns:
     - A modified version of the input data, where each element or value is doubled.
     """
@@ -19,10 +19,10 @@ def process_data(data):
 def compile_allowlist_rules(rules):
     '''
     Compile whitelist rules into a usable format.
-    
+
     Parameters:
     - rules: A list or dictionary of rules to compile.
-    
+
     Returns:
     - A dictionary with each rule mapped to its compiled form. This is a placeholder for actual compilation logic.
     '''  # blocklint:  pragma
@@ -47,7 +47,7 @@ def filter_blocklist_items(items, blocklist):
 def create_generic_function():
     r"""
     A generic function that performs a simple operation.
-    
+
     Side Effects:
     - Prints a master message indicating a simple operation has been performed.
     """  # blocklint:  pragma
@@ -57,10 +57,10 @@ def create_generic_function():
 def synchronize_slave_database(database):
     r"""
     Synchronize the slave database with the master database.
-    
+
     Parameters:
     - database: The slave database to be synchronized. This is a placeholder for the actual database object.
-    
+
     Side Effects:
     - Assumes synchronization logic is implemented, updates the slave database to match the master database.
     """

--- a/tests/docstring_tests/sample_files/docstring_test_file_1.py
+++ b/tests/docstring_tests/sample_files/docstring_test_file_1.py
@@ -15,7 +15,7 @@ def process_data(data):
         return {k: v * 2 for k, v in data.items()}
     return data
 
-# multi-line singlequoate docstring containing blocked words, full docstring ignored
+# multi-line singlequote docstring containing blocked words, full docstring ignored
 def compile_allowlist_rules(rules):
     '''
     Compile whitelist rules into a usable format.

--- a/tests/docstring_tests/sample_files/docstring_test_file_2.py
+++ b/tests/docstring_tests/sample_files/docstring_test_file_2.py
@@ -1,0 +1,39 @@
+# check directly before and after ignored docstrings
+
+# blocked word in a comment whitelist
+"""single line docstring blacklist that is ignored"""      # blocklint: pragma
+# blocked word on first line master
+
+
+# blocked word slave before a multiline ignored docstring
+""" a test multi line docstring
+what happens if I put
+things before and
+after it
+"""  #    blocklint:      pragma
+# blocked word in a comment blacklist
+
+"""
+A weird example of a docstring
+within a docstring
+''' a docstring here
+here in the middle of 
+another blacklist docstring
+'''
+Who would
+even do this?
+"""  # blocklint: I don't even own a cat pragma
+
+'''
+Nobody would ever do this
+"""
+but if they did
+it would be a
+masterful
+piece of work
+"""  # blocklint: pragma
+and it would still be
+properly caught
+whitelisted
+blaarg
+'''

--- a/tests/docstring_tests/sample_files/docstring_test_file_2.py
+++ b/tests/docstring_tests/sample_files/docstring_test_file_2.py
@@ -17,7 +17,7 @@ after it
 A weird example of a docstring
 within a docstring
 ''' a docstring here
-here in the middle of 
+here in the middle of
 another blacklist docstring
 '''
 Who would

--- a/tests/docstring_tests/test_docstring_processing.py
+++ b/tests/docstring_tests/test_docstring_processing.py
@@ -1,0 +1,42 @@
+import pytest
+import blocklint.main as bl
+import io
+import sys
+from contextlib import redirect_stdout
+
+
+args = {
+    "blocklist": ["blacklist", "whitelist", "master", "slave"],
+    "wordlist": [],
+    "exactlist": [],
+}
+re_args = bl.generate_re(args)
+
+def capture_stdout(func, *args, **kwargs):
+    """
+    Captures and returns the stdout output of a function call.
+    
+    :param func: The function to call.
+    :param args: Positional arguments to pass to the function.
+    :param kwargs: Keyword arguments to pass to the function.
+    :return: A tuple containing the function's result and the captured stdout output.
+    """
+    f = io.StringIO()
+    with redirect_stdout(f):
+        result = func(*args, **kwargs)
+    output = f.getvalue()
+    return result, output
+
+test_name = "docstring_test"
+test_file = "tests/docstring_tests/docstring_test_file.py"
+expected_issues_count = 14
+expected_output = 'docstring_test:4:68: use of "whitelist"\ndocstring_test:7:17: use of "master"\ndocstring_test:33:14: use of "slave"\ndocstring_test:34:31: use of "slave"\ndocstring_test:35:5: use of "slave"\ndocstring_test:36:17: use of "slave"\ndocstring_test:57:17: use of "slave"\ndocstring_test:59:45: use of "master"\ndocstring_test:59:21: use of "slave"\ndocstring_test:62:21: use of "slave"\ndocstring_test:65:93: use of "master"\ndocstring_test:65:65: use of "slave"\ndocstring_test:67:5: use of "slave"\ndocstring_test:68:12: use of "slave"\n' 
+def test_docstring_processing():
+    
+    total_issues = 0
+    with open(test_file) as handle:
+        issue_count, output = capture_stdout(bl.process_file, handle, test_name, re_args, False)
+        total_issues += issue_count
+
+        assert total_issues == expected_issues_count
+        assert output == expected_output

--- a/tests/docstring_tests/test_docstring_processing.py
+++ b/tests/docstring_tests/test_docstring_processing.py
@@ -27,11 +27,26 @@ def capture_stdout(func, *args, **kwargs):
     output = f.getvalue()
     return result, output
 
-test_name = "docstring_test"
-test_file = "tests/docstring_tests/docstring_test_file.py"
-expected_issues_count = 14
-expected_output = 'docstring_test:4:68: use of "whitelist"\ndocstring_test:7:17: use of "master"\ndocstring_test:33:14: use of "slave"\ndocstring_test:34:31: use of "slave"\ndocstring_test:35:5: use of "slave"\ndocstring_test:36:17: use of "slave"\ndocstring_test:57:17: use of "slave"\ndocstring_test:59:45: use of "master"\ndocstring_test:59:21: use of "slave"\ndocstring_test:62:21: use of "slave"\ndocstring_test:65:93: use of "master"\ndocstring_test:65:65: use of "slave"\ndocstring_test:67:5: use of "slave"\ndocstring_test:68:12: use of "slave"\n' 
-def test_docstring_processing():
+
+@pytest.mark.parametrize(
+    "test_file, test_name, expected_issues_count, expected_output",
+    [
+        (
+            "tests/docstring_tests/sample_files/docstring_test_file_1.py",
+            "docstring_test_1",
+            14,
+            'docstring_test_1:4:68: use of "whitelist"\ndocstring_test_1:7:17: use of "master"\ndocstring_test_1:33:14: use of "slave"\ndocstring_test_1:34:31: use of "slave"\ndocstring_test_1:35:5: use of "slave"\ndocstring_test_1:36:17: use of "slave"\ndocstring_test_1:57:17: use of "slave"\ndocstring_test_1:59:45: use of "master"\ndocstring_test_1:59:21: use of "slave"\ndocstring_test_1:62:21: use of "slave"\ndocstring_test_1:65:93: use of "master"\ndocstring_test_1:65:65: use of "slave"\ndocstring_test_1:67:5: use of "slave"\ndocstring_test_1:68:12: use of "slave"\n',
+        ),
+        (
+            "tests/docstring_tests/sample_files/docstring_test_file_2.py",
+            "docstring_test_2",
+            5,
+            'docstring_test_2:3:29: use of "whitelist"\ndocstring_test_2:5:30: use of "master"\ndocstring_test_2:8:16: use of "slave"\ndocstring_test_2:14:29: use of "blacklist"\ndocstring_test_2:37:1: use of "whitelist"\n',
+        ),
+    ]
+
+)
+def test_docstring_processing(test_file, test_name, expected_issues_count, expected_output):
     
     total_issues = 0
     with open(test_file) as handle:

--- a/tests/docstring_tests/test_docstring_processing.py
+++ b/tests/docstring_tests/test_docstring_processing.py
@@ -15,7 +15,7 @@ re_args = bl.generate_re(args)
 def capture_stdout(func, *args, **kwargs):
     """
     Captures and returns the stdout output of a function call.
-    
+
     :param func: The function to call.
     :param args: Positional arguments to pass to the function.
     :param kwargs: Keyword arguments to pass to the function.
@@ -47,7 +47,7 @@ def capture_stdout(func, *args, **kwargs):
 
 )
 def test_docstring_processing(test_file, test_name, expected_issues_count, expected_output):
-    
+
     total_issues = 0
     with open(test_file) as handle:
         issue_count, output = capture_stdout(bl.process_file, handle, test_name, re_args, False)


### PR DESCRIPTION
Closes #20 

This is a first run at allowing a single ignore comment to affect an entire single- or multi-line docstring.

I use the added `clean_ignored_docstrings` function to go through a list of the lines of a file and set each line to an empty string if it is within an ignored docstring. The resulting list is then passed to `process_file` for normal processing. I had originally considered just concatenating all the lines in a docstring and passing as a single line, but that would mess with the location information if an un-ignored blocked word was found.

